### PR TITLE
Reserve Suggestions

### DIFF
--- a/contracts/Lock.sol
+++ b/contracts/Lock.sol
@@ -1,39 +1,34 @@
 pragma solidity ^0.8.0;
 // SPDX-License-Identifier: MIT
 import "node_modules/@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import "node_modules/@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 
-contract ERC20Lock{
+contract ERC20Lock {
     
     using SafeERC20 for IERC20;
     
     address public owner;
-   
+
     
-    event TokenReceived(address indexed to, uint amount);// Log the event about a deposit being made by an address and its amount
-    event TokenSent(address indexed to,uint amount); // Log the even about withdrawal being made
+    event TokenReceived(address indexed token, address indexed from, uint amount);// Log the event about a deposit being made by an address and its amount
+    event TokenSent(address indexed token, address indexed to, uint amount); // Log the even about withdrawal being made
     
-    
-    constructor (){ 
+    constructor () { 
         owner = msg.sender;
     }
-    
-   modifier onlyOwner() {
-    require(msg.sender == owner);
-    _;
-}
 
-function deposit(address token, uint amount)external {
-    IERC20(token).transferFrom(msg.sender, address(this), amount);
-    emit TokenReceived(to,amount);
-}
-  receive() external payable{}
-    
-
-function withdraw(IERC20 token, address recipient, uint256 amount) external onlyOwner{
-       if (token == address(0)){
-           recipient.transfer(amount);
-       }else{
-        token.transfer(recipient, amount);
+    function deposit(address token, uint amount) external {
+        IERC20(token).safeTransferFrom(msg.sender, address(this), amount);
+        emit TokenReceived(token, msg.sender, amount);
     }
-  
+
+    function withdraw(address token, address recipient, uint256 amount) external {
+        require(msg.sender == owner);
+        if (token == address(0)){
+            recipient.transfer(amount);
+        } else {
+            IERC20(token).safeTransfer(recipient, amount);
+        }
+        emit TokenSent(token, recipient, amount);
+    }
 }

--- a/contracts/Lock.sol
+++ b/contracts/Lock.sol
@@ -13,8 +13,8 @@ contract ERC20Lock {
     event TokenReceived(address indexed token, address indexed from, uint amount);// Log the event about a deposit being made by an address and its amount
     event TokenSent(address indexed token, address indexed to, uint amount); // Log the even about withdrawal being made
     
-    constructor () { 
-        owner = msg.sender;
+    constructor (address owner_) { 
+        owner = owner_;
     }
 
     function deposit(address token, uint amount) external {


### PR DESCRIPTION
Some explanations of changes:
- No need to have a payable function. This contract isn't trying to receive Ether. There are some [really crazy outlier cases](https://ethereum.stackexchange.com/questions/63987/can-a-contract-with-no-payable-function-have-ether) that cause a contract to have Ether anyway, so I left an escape hatch in `withdraw` anyway. 
- Instead of just using the deployment key as the owner, I added an arg to the constructor so that you can deploy with a less-secure key than the one you use to custody the funds.
- Added use of SafeMath. Good practice.   